### PR TITLE
msm8937-common: sepolicy: Address USB HID gadget denials

### DIFF
--- a/sepolicy/vendor/device.te
+++ b/sepolicy/vendor/device.te
@@ -1,2 +1,3 @@
 type fingerprint_device, dev_type;
 type laser_device, dev_type;
+type hid_gadget_device, dev_type, mlstrustedobject;

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -28,6 +28,9 @@
 /sys/devices/soc/soc:qcom,bcl/power_supply/bcl/type u:object_r:sysfs_healthd:s0
 /sys/devices/soc/msm-bcl-19/power_supply/fg_adc/type u:object_r:sysfs_healthd:s0
 
+# HID Gadget
+/dev/hidg[0-9]*          u:object_r:hid_gadget_device:s0
+
 # Init scripts
 /(vendor|system/vendor)/bin/init\.mmi\.(laser|usb)\.sh u:object_r:qti_init_shell_exec:s0
 

--- a/sepolicy/vendor/untrusted_app.te
+++ b/sepolicy/vendor/untrusted_app.te
@@ -1,1 +1,2 @@
 dontaudit untrusted_app proc:file r_file_perms;
+allow { untrusted_app untrusted_app_25 } hid_gadget_device:chr_file { rw_file_perms getattr };


### PR DESCRIPTION
* The driver is present, though not enabled in the kernel
* I made this commit anyway to allow users to use this feature without
  recompiling the whole ROM
* yes, mlstrustedobject and all this is needed and no, it does not
  create an security hole
* those rules have no effect without the feature enabled in the kernel

Change-Id: Ifa46acba3f25cce95b30521968f10fa71a372e8d

P.S.: There is no authorship because I had to figure out those rules myself, kanging from other devices did not work.